### PR TITLE
feat: Add session snapshots to 'Ver Detalhes' for unprocessed billing…

### DIFF
--- a/clinic-api/src/routes/monthly-billing.ts
+++ b/clinic-api/src/routes/monthly-billing.ts
@@ -51,13 +51,13 @@ router.get("/summary", asyncHandler(async (req, res) => {
             userAccessToken
         );
 
-        console.log('=== MONTHLY BILLING SUMMARY DEBUG ===');
-        console.log('therapistEmail:', therapistEmail);
-        console.log('year:', year, 'month:', month);
-        console.log('summary:', summary);
-        console.log('userAccessToken:', userAccessToken ? 'Present' : 'Missing');
-        console.log('Headers x-calendar-token:', req.headers['x-calendar-token'] ? 'Present' : 'Missing');
-        console.log('Headers x-google-access-token:', req.headers['x-google-access-token'] ? 'Present' : 'Missing');
+        // console.log('=== MONTHLY BILLING SUMMARY DEBUG ===');
+        // console.log('therapistEmail:', therapistEmail);
+        // console.log('year:', year, 'month:', month);
+        // console.log('summary:', summary);
+        // console.log('userAccessToken:', userAccessToken ? 'Present' : 'Missing');
+        // console.log('Headers x-calendar-token:', req.headers['x-calendar-token'] ? 'Present' : 'Missing');
+        // console.log('Headers x-google-access-token:', req.headers['x-google-access-token'] ? 'Present' : 'Missing');
 
         return res.json({
             year,

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -92,22 +92,6 @@ export const TherapistOnboarding: React.FC<TherapistOnboardingProps> = ({
     }
   };
 
-  const getProgressPercentage = (): number => {
-    if (mode === "addPatient") {
-      return 100;
-    }
-
-    const stepMap: Record<string, number> = {
-      welcome: 20,
-      auth: 40,
-      "calendar-selection": 60,
-      calendar: 70,
-      success: 80,
-      "import-wizard": 90,  // ADD THIS LINE
-      addPatients: 100
-    };
-    return stepMap[state.step] || 20;
-  };
 
   const handleGetStarted = async () => {
     setIsLoading(true);
@@ -400,19 +384,19 @@ export const TherapistOnboarding: React.FC<TherapistOnboardingProps> = ({
           </View>
         )}
 
-        <View style={styles.successInfo}>
+        {/* <View style={styles.successInfo}>
           <Text style={styles.infoTitle}>Próximo passo:</Text>
           <Text style={styles.infoItem}>• Importe seus pacientes do calendário automaticamente</Text>
           <Text style={styles.infoItem}>• Ou adicione pacientes manualmente mais tarde</Text>
-        </View>
+        </View> */}
 
         <View style={styles.buttonContainer}>
-          <Pressable
+          {/* <Pressable
             style={styles.secondaryButton}
             onPress={() => setState(prev => ({ ...prev, step: "import-wizard" }))}
           >
             <Text style={styles.secondaryButtonText}>📅 Importar do Calendário</Text>
-          </Pressable>
+          </Pressable> */}
 
           <Pressable
             style={styles.primaryButton}


### PR DESCRIPTION
… periods

- Add sessionSnapshots field to BillingSummary interface for unprocessed patients
- Format calendar sessions into snapshots on backend in getBillingSummary()
- Simplify viewBillingPeriodDetails to use pre-formatted snapshots from billing summary
- Enable 'Ver Detalhes' button functionality for all payment states (can_process, processed, paid)
- Unify session snapshot display format between processed and unprocessed billing periods
- Remove complex calendar API calls from frontend - now uses optimized backend data
- Fix calendar ID mismatch issue by using therapist's selected calendar instead of env variable

Now therapists can preview session details before processing charges, showing actual calendar appointments with dates, times, and Google event IDs in a consistent format across all billing states.